### PR TITLE
Fix buffer overflow with memmove leading to IDA crashing

### DIFF
--- a/gc_wii_dol_loader.py
+++ b/gc_wii_dol_loader.py
@@ -26,7 +26,8 @@ def get_dol_header(li):
     li.seek(0)
     header = DolHeader()
     string = li.read(DolHeaderSize)
-    memmove(addressof(header), string, DolHeaderSize)
+    fit = min(len(string), sizeof(header))
+    memmove(addressof(header), string, fit)
     return header
 
 def section_sanity_check(offset, addr, size, file_len):


### PR DESCRIPTION
With IDA 6.8 and this plugin installed, IDA crashes at startup on files that arent `.dol`. This patch fixes it.